### PR TITLE
いいね一覧の表示エラーを修正

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,9 +2,9 @@ class FavoritesController < ApplicationController
   before_action :set_event
 
   def index
-    favorites = Favorite.where(user_id: current_user.id)
+    favorite_event_ids = Favorite.where(user_id: current_user.id).pluck(:event_id)
     @finished_events = Event.where('finish_at < ?', Date.today)
-    @events = Event.where(id: favorites.ids).where.not(id: @finished_events.ids)
+    @events = Event.where(id: favorite_event_ids).where.not(id: @finished_events.ids)
   end
 
   def create

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'Favorite', type: :request do
+  let(:user) { create(:user) }
+  let(:title) { create(:title) }
+  let(:post) { create(:post) }
+
+  describe 'Favorite' do
+    describe 'ログインユーザー' do
+      before do
+        allow_any_instance_of(ActionDispatch::Request)
+          .to receive(:session)
+          .and_return({ user_id: user.id })
+      end
+
+      it 'GET index' do
+        get user_favorites_path(user)
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Favorite, type: :system, js: true do
         describe 'いいね一覧' do
           before do
             visit event_path(event)
-            expect(page).to have_css '#favorite-destroy'
+            find('#favorite-create').click
             visit user_favorites_path(user)
           end
 

--- a/spec/system/favorites_spec.rb
+++ b/spec/system/favorites_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Favorite, type: :system, js: true do
   let(:event) { create(:event) }
   let!(:spot) { create(:spot) }
   let!(:title) { create(:title) }
+  let!(:other_spot) { create(:other_spot) }
+  let!(:other_title) { create(:other_title) }
+  let!(:other_event) { create(:other_event) }
 
   describe 'Favorite' do
     describe 'いいね機能' do
@@ -26,6 +29,21 @@ RSpec.describe Favorite, type: :system, js: true do
             expect(page).to have_css '#favorite-destroy'
             find('#favorite-destroy').click
             expect(page).to have_css '#favorite-create'
+          end
+        end
+        describe 'いいね一覧' do
+          before do
+            visit event_path(event)
+            expect(page).to have_css '#favorite-destroy'
+            visit user_favorites_path(user)
+          end
+
+          it 'いいねしたイベントが表示される' do
+            expect(page).to have_content title.name
+          end
+
+          it 'いいねしていないイベントが表示されない' do
+            expect(page).to_not have_content other_title.name
           end
         end
       end


### PR DESCRIPTION
・favorites_controllerで取得するidの設定もれがあったため修正しました
・今回のエラーに関するテストが漏れていたため、テスト内容を変更しました