### PR TITLE
アクセス制限の脆弱性を解消

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,9 @@ Style/StringLiterals:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/SymbolArray:
+  EnforcedStyle: brackets  
+
 Style/Lambda:
   EnforcedStyle: literal
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,16 @@ class ApplicationController < ActionController::Base
   before_action :set_popular_events
   include SessionsHelper
 
+  def autheniticate_user
+    if current_user.nil?
+      flash[:notice]="ログインが必要です"
+      redirect_to("/login")
+    elsif current_user.id != params[:id].to_i
+      flash[:alert]="閲覧権限がないため、表示できませんでした"
+      redirect_to("/login")
+    end
+  end
+
   def set_popular_events
     @popular_events = Event.popular_events
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,10 +5,10 @@ class ApplicationController < ActionController::Base
 
   def autheniticate_user
     if current_user.nil?
-      flash[:notice]="ログインが必要です"
+      flash[:notice] = "ログインが必要です"
       redirect_to("/login")
     elsif current_user.id != params[:id].to_i
-      flash[:alert]="閲覧権限がないため、表示できませんでした"
+      flash[:alert] = "閲覧権限がないため、表示できませんでした"
       redirect_to("/login")
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :autheniticate_user, only: :edit, :update
+  before_action :autheniticate_user, only: [:edit, :update]
 
   def new
     @user = User.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :autheniticate_user, {only: [:edit, :update]}
+  before_action :autheniticate_user, only: :edit, :update
 
   def new
     @user = User.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :autheniticate_user, {only: [:edit, :update]}
+
   def new
     @user = User.new
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :system, js: true do
   let(:user) { create(:user) }
-  let(:other_user) { create(:user) }
+  let!(:other_user) { create(:user) }
   let!(:prefecture) { create(:prefecture) }
 
   describe 'User' do
@@ -53,6 +53,13 @@ RSpec.describe User, type: :system, js: true do
           end
         end
       end
+      describe 'アクセス制限' do
+        it 'ユーザー編集ページへのアクセスするとログイン画面に遷移する' do
+          visit user_edit_path(other_user)
+          expect(current_path).to eq login_path
+          expect(page).to have_content 'ログインが必要です'
+        end
+      end
     end
     describe 'ログイン後' do
       before { login(user) }
@@ -78,6 +85,13 @@ RSpec.describe User, type: :system, js: true do
             click_button '変更した内容を保存する'
             expect(current_path).to eq user_path(user)
             expect(page).to have_content '変更内容にエラーがあります'
+          end
+        end
+        describe 'アクセス制限' do
+          it '他のユーザーの編集ページへのアクセスするとログイン画面に遷移する' do
+            visit user_edit_path(other_user)
+            expect(current_path).to eq login_path
+            expect(page).to have_content '閲覧権限がないため、表示できませんでした'
           end
         end
       end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe User, type: :system, js: true do
       end
       describe 'アクセス制限' do
         it 'ユーザー編集ページへのアクセスするとログイン画面に遷移する' do
-          visit user_edit_path(other_user)
+          visit edit_user_path(other_user)
           expect(current_path).to eq login_path
           expect(page).to have_content 'ログインが必要です'
         end
@@ -89,7 +89,7 @@ RSpec.describe User, type: :system, js: true do
         end
         describe 'アクセス制限' do
           it '他のユーザーの編集ページへのアクセスするとログイン画面に遷移する' do
-            visit user_edit_path(other_user)
+            visit edit_user_path(other_user)
             expect(current_path).to eq login_path
             expect(page).to have_content '閲覧権限がないため、表示できませんでした'
           end


### PR DESCRIPTION
ユーザー編集ページへURLでのアクセスだと閲覧可能な状態だったので、ログインユーザーのみが閲覧できるように制限しました。
・application_controller.rb,user_controller.rbで上記内容の追加
・system/user_spec.rbに上記内容を確認するテストを追加