### PR TITLE
カラム名の修正

### DIFF
--- a/db/migrate/20220309091258_create_event_tags.rb
+++ b/db/migrate/20220309091258_create_event_tags.rb
@@ -6,6 +6,6 @@ class CreateEventTags < ActiveRecord::Migration[6.1]
 
       t.timestamps
     end
-    add_index :post_tags, [:post_id, :tag_id], unique: true
+    add_index :event_tags, [:post_id, :tag_id], unique: true
   end
 end


### PR DESCRIPTION
マイグレーションファイル内にカラム名の誤りがあったため修正