### PR TITLE
タグ検索と人気のイベントの表示を修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -165,10 +165,9 @@ main{
 .popular-event{
   margin: 15px 5px;
   padding: 10px;
-  border-radius: 7px;
+  border-radius: 5px;
   height:150px;
-  border:3px solid #FFD700;
-  background-color: #FFFFE0;
+  background-color: #FFF0F5;
 }
 
 .popular-event img{
@@ -195,18 +194,22 @@ main{
   float: left;
 }
 
+.tag-text{
+ display: inline-block;
+}
+
 .tag-item{
   margin: 3px;
   padding: 3px;
   text-decoration: none;
-  color: #33CC66;
-  border: 2px solid #33CC66;
+  color: #FF66FF;
+  border: 2px solid #FF66FF;
   border-radius: 3px;
 }
 
 .tag a:hover{
-  color: #FFCC00;
-  border: 2px solid #FFCC00;
+  color: #9966FF;
+  border: 2px solid #9966FF;
 }
 
 .flash{

--- a/app/views/layouts/_popular_event.html.erb
+++ b/app/views/layouts/_popular_event.html.erb
@@ -1,5 +1,6 @@
 <div class="popular-event">
   <div class="info">
+    <%= "#{popular_event_counter+1}" %>
     <%= link_to popular_event.name, event_path(popular_event) %>
     <%= image_tag popular_event.image %>
     <p>会場: <%= link_to popular_event.place, spot_path(popular_event.spot_id) %><p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,11 +31,14 @@
         </div>
       <% end %>
       <div class="main-section">
-        <div class="tag">
-          <% Tag.all.each do |tag| %>
-            <%= link_to "##{tag.name}", "/tag/#{tag.id}", class: "tag-item" %>
-          <% end %>
-        </div>
+        <% if %w[home events].any? { |name| current_page?(send("#{name}_path")) } %>
+          <div class="tag">
+            <p class="tag-text">注目のタグ→</p>
+            <% Tag.all.each do |tag| %>
+              <%= link_to "##{tag.name}", "/tag/#{tag.id}", class: "tag-item" %>
+            <% end %>
+          </div>
+        <% end %>
         <%= yield %>
       </div>
     </main>


### PR DESCRIPTION
・タグのみの表示から、タグをクリックすることでイベントが見れることが分かるような表記に修正
・人気のイベントの一覧にて、それぞれの順位をイベント名の冒頭に追加
・上記の修正に伴い、タグ、人気イベントの表示（カラーリング）の修正